### PR TITLE
update deprecated plugin and bump alpine version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.6
 MAINTAINER dlee@nvisia.com
 
 RUN apk add --update --no-cache --virtual=run-deps \
@@ -9,7 +9,7 @@ RUN apk add --update --no-cache --virtual=run-deps \
     tzdata \
     py2-pip
 
-RUN pip install certbot-route53
+RUN pip install certbot-dns-route53
 
 WORKDIR /
 


### PR DESCRIPTION
_certbot_route53_ has been deprecated in favor of **certbot_dns_route53** and is now just a simple shim around it (ref: https://github.com/lifeonmarspt/certbot-route53).
Also bumping alpine to latest stable version.